### PR TITLE
RDKEMW-2055: Add appId parameter to run api for

### DIFF
--- a/RuntimeManager/ApplicationConfiguration.h
+++ b/RuntimeManager/ApplicationConfiguration.h
@@ -28,6 +28,8 @@ namespace Plugin
 {
     struct ApplicationConfiguration
     {
+        std::string mAppId;
+
         std::string mAppInstanceId;
         
         // command to run inside the container, mArgs[0] is application name

--- a/RuntimeManager/RuntimeManagerImplementation.cpp
+++ b/RuntimeManager/RuntimeManagerImplementation.cpp
@@ -586,7 +586,7 @@ err_ret:
             return runtimeState;
         }
 
-        Core::hresult RuntimeManagerImplementation::Run(const string& appInstanceId, const string& appPath, const string& runtimePath, IStringIterator* const& envVars, const uint32_t userId, const uint32_t groupId, IValueIterator* const& ports, IStringIterator* const& paths, IStringIterator* const& debugSettings)
+        Core::hresult RuntimeManagerImplementation::Run(const string& appId, const string& appInstanceId, const string& appPath, const string& runtimePath, IStringIterator* const& envVars, const uint32_t userId, const uint32_t groupId, IValueIterator* const& ports, IStringIterator* const& paths, IStringIterator* const& debugSettings)
         {
             Core::hresult status = Core::ERROR_GENERAL;
             RuntimeAppInfo runtimeAppInfo;
@@ -596,6 +596,7 @@ err_ret:
 
             /* Below code to be enabled once dobbySpec generator ticket is ready */
             ApplicationConfiguration config;
+            config.mAppId = appId;
             config.mAppInstanceId = appInstanceId;
             config.mAppPath = {appPath};
             config.mRuntimePath = runtimePath;
@@ -698,6 +699,10 @@ err_ret:
                 if (status == Core::ERROR_NONE)
                 {
                     LOGINFO("Update Info for %s",appInstanceId.c_str());
+                    if (!appId.empty())
+                    {
+                        runtimeAppInfo.appId = std::move(appId);
+                    }
                     runtimeAppInfo.appInstanceId = std::move(appInstanceId);
                     runtimeAppInfo.appPath = std::move(appPath);
                     runtimeAppInfo.runtimePath = std::move(runtimePath);

--- a/RuntimeManager/RuntimeManagerImplementation.h
+++ b/RuntimeManager/RuntimeManagerImplementation.h
@@ -93,6 +93,7 @@ namespace WPEFramework
 
                 typedef struct _RuntimeAppInfo
                 {
+                    std::string appId;
                     std::string appInstanceId;
                     std::string appPath;
                     std::string runtimePath;
@@ -164,7 +165,7 @@ namespace WPEFramework
                 virtual Core::hresult Register(Exchange::IRuntimeManager::INotification *notification) override;
                 virtual Core::hresult Unregister(Exchange::IRuntimeManager::INotification *notification) override;
 
-                virtual Core::hresult Run(const string& appInstanceId, const string& appPath, const string& runtimePath, IStringIterator* const& envVars, const uint32_t userId, const uint32_t groupId, IValueIterator* const& ports, IStringIterator* const& paths, IStringIterator* const& debugSettings);
+                virtual Core::hresult Run(const string& appId, const string& appInstanceId, const string& appPath, const string& runtimePath, IStringIterator* const& envVars, const uint32_t userId, const uint32_t groupId, IValueIterator* const& ports, IStringIterator* const& paths, IStringIterator* const& debugSettings);
                 virtual Core::hresult Hibernate(const string& appInstanceId) override;
                 virtual Core::hresult Wake(const string& appInstanceId, const RuntimeState runtimeState) override;
                 virtual Core::hresult Suspend(const string& appInstanceId) override;


### PR DESCRIPTION
StorageManager use

Reason for change : Add appId as an argument to
run method
Test Procedure: Check if appId is stored in database if passed Risks: Low
Priority: P1
Signed-off-by: Pavithra V pavviswa@synamedia.com