### PR TITLE
RDKEMW-1023 Failed to create plugin interface for PowerManager

### DIFF
--- a/Telemetry/TelemetryImplementation.cpp
+++ b/Telemetry/TelemetryImplementation.cpp
@@ -73,7 +73,6 @@ namespace Plugin {
         LOGINFO("Create TelemetryImplementation Instance");
         TelemetryImplementation::_instance = this;
         Utils::Telemetry::init();
-        InitializePowerManager();
     }
 
     TelemetryImplementation::~TelemetryImplementation()
@@ -354,6 +353,7 @@ namespace Plugin {
         ASSERT(service != nullptr);
         _service = service;
         _service->AddRef();
+        InitializePowerManager();
 
 #ifdef HAS_RBUS        
         activateSystemPluginandGetPrivacyMode();


### PR DESCRIPTION
Reason for change: Resolved the PowerManager plugin interface creation failure. 
Test Procedure: check the  PowerManager plugin interface creation.
Risks: Medium
Priority: P1
Signed-off-by:Dineshkumar P dinesh_kumar2@comcast.com