### PR TITLE
RDK-56621: Update all the power manager plugin clients to new register events

### DIFF
--- a/Telemetry/TelemetryImplementation.cpp
+++ b/Telemetry/TelemetryImplementation.cpp
@@ -368,6 +368,7 @@ namespace Plugin {
         LOGINFO("Connect the COM-RPC socket\n");
         _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
                             .withIShell(_service)
+                            .withRetry(25)
                             .createInterface();
 
         registerEventHandlers();
@@ -381,7 +382,7 @@ namespace Plugin {
         if(!_registeredEventHandlers && _powerManagerPlugin) 
         {
             _registeredEventHandlers = true;
-            _powerManagerPlugin->Register(&_pwrMgrNotification);
+            _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModeChangedNotification>());
         }
     }
 

--- a/Telemetry/TelemetryImplementation.cpp
+++ b/Telemetry/TelemetryImplementation.cpp
@@ -368,7 +368,8 @@ namespace Plugin {
         LOGINFO("Connect the COM-RPC socket\n");
         _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
                             .withIShell(_service)
-                            .withRetry(25)
+                            .withRetryIntervalMS(200)
+                            .withRetryCount(25)
                             .createInterface();
 
         registerEventHandlers();

--- a/Telemetry/TelemetryImplementation.h
+++ b/Telemetry/TelemetryImplementation.h
@@ -38,7 +38,7 @@ namespace Plugin {
     class TelemetryImplementation : public Exchange::ITelemetry, public Exchange::IConfiguration
     {
         private:
-            class PowerManagerNotification : public Exchange::IPowerManager::INotification {
+            class PowerManagerNotification : public Exchange::IPowerManager::IModeChangedNotification {
             private:
                 PowerManagerNotification(const PowerManagerNotification&) = delete;
                 PowerManagerNotification& operator=(const PowerManagerNotification&) = delete;
@@ -55,14 +55,16 @@ namespace Plugin {
                 {
                     _parent.onPowerModeChanged(currentState, newState);
                 }
-                void OnPowerModePreChange(const PowerState &currentState, const PowerState &newState) override {}
-                void OnDeepSleepTimeout(const int &wakeupTimeout) override {}
-                void OnNetworkStandbyModeChanged(const bool &enabled) override {}
-                void OnThermalModeChanged(const ThermalTemperature &currentThermalLevel, const ThermalTemperature &newThermalLevel, const float &currentTemperature) override {}
-                void OnRebootBegin(const string &rebootReasonCustom, const string &rebootReasonOther, const string &rebootRequestor) override {}
+
+                template <typename INTERFACE>
+                T* baseInterface()
+                {
+                    static_assert(std::is_base_of<T, Notification>(), "base type mismatch");
+                    return static_cast<T*>(this);
+                }
 
                 BEGIN_INTERFACE_MAP(PowerManagerNotification)
-                INTERFACE_ENTRY(Exchange::IPowerManager::INotification)
+                INTERFACE_ENTRY(Exchange::IPowerManager::IModeChangedNotification)
                 END_INTERFACE_MAP
 
             private:

--- a/Telemetry/TelemetryImplementation.h
+++ b/Telemetry/TelemetryImplementation.h
@@ -59,7 +59,7 @@ namespace Plugin {
                 template <typename T>
                 T* baseInterface()
                 {
-                    static_assert(std::is_base_of<T, Notification>(), "base type mismatch");
+                    static_assert(std::is_base_of<T, PowerManagerNotification>(), "base type mismatch");
                     return static_cast<T*>(this);
                 }
 

--- a/Telemetry/TelemetryImplementation.h
+++ b/Telemetry/TelemetryImplementation.h
@@ -56,7 +56,7 @@ namespace Plugin {
                     _parent.onPowerModeChanged(currentState, newState);
                 }
 
-                template <typename INTERFACE>
+                template <typename T>
                 T* baseInterface()
                 {
                     static_assert(std::is_base_of<T, Notification>(), "base type mismatch");

--- a/helpers/PluginInterfaceBuilder.h
+++ b/helpers/PluginInterfaceBuilder.h
@@ -101,6 +101,7 @@ namespace Plugin {
         WPEFramework::PluginHost::IShell* controller = builder.controller();
         const std::string& callsign = builder.callSign();
         const int retry_count = builder.retryCount();
+        const uint32_t retry_interval = builder.retryInterval();
         int count = 0;
 
         if (!controller) {
@@ -118,7 +119,7 @@ namespace Plugin {
             else
             {
                 count++;
-                usleep(200*1000);
+                usleep(retry_interval*1000);
             }
         }while(count < retry_count);
 
@@ -139,6 +140,7 @@ namespace Plugin {
         uint32_t _version;
         uint32_t _timeout;
         int _retry_count;
+        uint32_t _retry_interval;
 
     public:
         PluginInterfaceBuilder(const char* callsign)
@@ -147,6 +149,7 @@ namespace Plugin {
             , _version(static_cast<uint32_t>(~0))
             , _timeout(3000)
             ,_retry_count(0)
+            ,_retry_interval(0)
         {
         }
 
@@ -171,7 +174,13 @@ namespace Plugin {
             return *this;
         }
 
-        inline PluginInterfaceBuilder& withRetry(int retryCount)
+        inline PluginInterfaceBuilder& withRetryIntervalMS(int retryInterval)
+        {
+            _retry_interval = retryInterval;
+            return *this;
+        }
+
+        inline PluginInterfaceBuilder& withRetryCount(int retryCount)
         {
             _retry_count = retryCount;
             return *this;
@@ -187,6 +196,11 @@ namespace Plugin {
 
             // pass on the ownership of controller to interfaceRef
             return std::move(PluginInterfaceRef<INTERFACE>(interface, _service));
+        }
+
+        const uint32_t retryInterval() const
+        {
+            return _retry_interval;
         }
 
         const int retryCount() const

--- a/helpers/PluginInterfaceBuilder.h
+++ b/helpers/PluginInterfaceBuilder.h
@@ -114,11 +114,13 @@ namespace Plugin {
 
             if (pluginInterface) {
                 pluginInterface->AddRef();
+                LOGINFO("plugin interface succeed and retry count: %d",count);
                 return pluginInterface;
             }
             else
             {
                 count++;
+                LOGERR("plugin interface failed and retry: %d",count);
                 usleep(retry_interval*1000);
             }
         }while(count < retry_count);

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -135,7 +135,8 @@ namespace WPEFramework
                 {
                     _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
                                       .withIShell(service)
-                                      .withRetry(25)
+                                      .withRetryIntervalMS(200)
+                                      .withRetryCount(25)
                                       .createInterface();
                 }
                 if (!s_instance)

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -135,6 +135,7 @@ namespace WPEFramework
                 {
                     _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
                                       .withIShell(service)
+                                      .withRetry(25)
                                       .createInterface();
                 }
                 if (!s_instance)


### PR DESCRIPTION
RDK-56621: Update all the power manager plugin clients to new register events

Reason for changes: The PowerManager plugin's events are separated into different classes
Test procedure: Full stack build