### PR TITLE
RDKEMW-2203: Typo in callsign for UsbDevice

### DIFF
--- a/USBDevice/USBDevice.cpp
+++ b/USBDevice/USBDevice.cpp
@@ -149,11 +149,13 @@ namespace WPEFramework
 
     void USBDevice::Deactivated(RPC::IRemoteConnection* connection)
     {
-        SYSLOG(Logging::Shutdown, (string(_T("USBDevice Deactivated"))));
-        if (connection->Id() == _connectionId) {
-            ASSERT(nullptr != _service);
+        if (connection->Id() == _connectionId)
+        {
+            SYSLOG(Logging::Shutdown, (string(_T("USBDevice Deactivated"))));
+            ASSERT(nullptr != _service)
             Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, PluginHost::IShell::FAILURE));
         }
     }
+
 } // namespace Plugin
 } // namespace WPEFramework

--- a/USBDevice/USBDevice.h
+++ b/USBDevice/USBDevice.h
@@ -59,12 +59,10 @@ namespace Plugin {
 
                 void Activated(RPC::IRemoteConnection*) override
                 {
-                    LOGINFO("USBDevice Notification Activated");
                 }
 
                 void Deactivated(RPC::IRemoteConnection *connection) override
                 {
-                   LOGINFO("USBDevice Notification Deactivated");
                    _parent.Deactivated(connection);
                 }
 

--- a/USBMassStorage/USBMassStorage.cpp
+++ b/USBMassStorage/USBMassStorage.cpp
@@ -175,7 +175,9 @@ namespace WPEFramework
 
     void USBMassStorage::Deactivated(RPC::IRemoteConnection* connection)
     {
-        if (connection->Id() == _connectionId) {
+        if (connection->Id() == _connectionId)
+        {
+            LOGINFO("USBMassStorage Deactivated");
             ASSERT(nullptr != _service);
             Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, PluginHost::IShell::FAILURE));
         }
@@ -183,12 +185,10 @@ namespace WPEFramework
 
     void USBMassStorage::Notification::Activated(RPC::IRemoteConnection*)
     {
-        LOGINFO("USBMassStorage Notification Activated");
     }
 
     void USBMassStorage::Notification::Deactivated(RPC::IRemoteConnection *connection)
     {
-       LOGINFO("USBMassStorage Notification Deactivated");
        _parent.Deactivated(connection);
     }
 


### PR DESCRIPTION
**Reason for change:**
Activated/Deactivated debug messages from USB plugins are misleading. Plugin has a debug log that says that
Activated/Deactivated for plugin status first and checking whether it is for own plugin by checking the channel Id. So, debug is moved inside if condition, where we verified the incoming channel Id is matched with current plugin.

**Test Procedure:**
Create full stack build and verify logs disappeared.
**Risks:** High
**Priority:** P1