### PR TITLE
RDKEMW-2359 Ensure events received inside appmanager

### DIFF
--- a/AppManager/LifecycleInterfaceConnector.h
+++ b/AppManager/LifecycleInterfaceConnector.h
@@ -42,6 +42,26 @@ namespace WPEFramework
     {
         class LifecycleInterfaceConnector
         {
+            private:
+            class NotificationHandler : public Exchange::ILifecycleManager::INotification {
+
+                public:
+                    NotificationHandler(LifecycleInterfaceConnector& parent) : mParent(parent){}
+                    ~NotificationHandler(){}
+
+                    void OnAppStateChanged(const string& appId, Exchange::ILifecycleManager::LifecycleState state, const string& errorReason)
+                    {
+                        mParent.OnAppStateChanged(appId, state, errorReason);
+                    }
+
+                    BEGIN_INTERFACE_MAP(NotificationHandler)
+                    INTERFACE_ENTRY(Exchange::ILifecycleManager::INotification)
+                    END_INTERFACE_MAP
+
+                private:
+                    LifecycleInterfaceConnector& mParent;
+            };
+
                 public/*members*/:
                     static LifecycleInterfaceConnector* _instance;
 
@@ -64,6 +84,7 @@ namespace WPEFramework
                 private:
                     mutable Core::CriticalSection mAdminLock;
                     Exchange::ILifecycleManager *mLifecycleManagerRemoteObject;
+                    Core::Sink<NotificationHandler> mNotification;
                     PluginHost::IShell* mCurrentservice;
         };
     }


### PR DESCRIPTION
Reason for change : Ensure events received inside appmanager
Test Procedure: launchApp is not crashing
Risks: Medium
Priority: P1
Signed-off-by: Dali Hariharan bp-dharih957@cable.comcast.com