### PR TITLE
RDKEMW-2278: Removal of WPEFrameworkSecurity Agent Utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ string(TOLOWER ${NAMESPACE} STORAGE_DIRECTORY)
 # for writing pc and config files
 include(CmakeHelperFunctions)
 
+option(DISABLE_SECURITY_TOKEN "Disable security token" ON)
+
+if(DISABLE_SECURITY_TOKEN)
+    add_definitions(-DDISABLE_SECURITY_TOKEN)
+endif()
 
 if(PLUGIN_USERSETTINGS)
     add_subdirectory(UserSettings)


### PR DESCRIPTION
Reason for change: Added DISABLE_SECURITY_TOKEN Flag to disable the WPEFrameworkSecurity Token generation changes
Test Procedure: please referred from the ticket
Risks: Medium
Signed-off-by: Thamim Razith <ThamimRazith_AbbasAli@comcast.com>