### PR TITLE
RDKEMW-2483: Out of range values are accepted by org.rdk.UserSettings setVoiceGuidanceRate api.

### DIFF
--- a/UserSettings/CHANGELOG.md
+++ b/UserSettings/CHANGELOG.md
@@ -16,7 +16,9 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-
+## [2.2.0] - 2025-02-18
+### Added
+- Add user settings inspector interface to user settings plugin.
 
 ## [2.1.0] - 2025-02-18
 ### Updated

--- a/UserSettings/UserSettings.cpp
+++ b/UserSettings/UserSettings.cpp
@@ -20,7 +20,7 @@
 #include "UserSettings.h"
 
 #define API_VERSION_NUMBER_MAJOR 2
-#define API_VERSION_NUMBER_MINOR 1
+#define API_VERSION_NUMBER_MINOR 2
 #define API_VERSION_NUMBER_PATCH 0
 
 namespace WPEFramework

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -64,6 +64,9 @@ const std::map<Exchange::IUserSettingsInspector::SettingsKey, string> UserSettin
          {Exchange::IUserSettingsInspector::SettingsKey::VOICE_GUIDANCE_RATE, USERSETTINGS_VOICE_GUIDANCE_RATE_KEY},
          {Exchange::IUserSettingsInspector::SettingsKey::VOICE_GUIDANCE_HINTS, USERSETTINGS_VOICE_GUIDANCE_HINTS_KEY}};
 
+const double UserSettingsImplementation::minVGR = 0.1;
+const double UserSettingsImplementation::maxVGR = 10;
+
 SERVICE_REGISTRATION(UserSettingsImplementation, 1, 0);
 
 UserSettingsImplementation::UserSettingsImplementation()
@@ -872,7 +875,14 @@ uint32_t UserSettingsImplementation::SetVoiceGuidanceRate(const double rate)
     uint32_t status = Core::ERROR_GENERAL;
 
     LOGINFO("rate: %lf", rate);
-    status = SetUserSettingsValue(USERSETTINGS_VOICE_GUIDANCE_RATE_KEY, std::to_string(rate));
+    if (minVGR <= rate && maxVGR >= rate)
+    {
+        status = SetUserSettingsValue(USERSETTINGS_VOICE_GUIDANCE_RATE_KEY, std::to_string(rate));
+    }
+    else
+    {
+        status = Core::ERROR_INVALID_PARAMETER;
+    }
     return status;
 }
 

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -60,6 +60,8 @@ namespace Plugin {
     public:
         static const std::map<string, string> usersettingsDefaultMap;
         static const std::map<SettingsKey, string> _userSettingsInspectorMap;
+	static const double minVGR;
+	static const double maxVGR;
 
     private:
         class Store2Notification : public Exchange::IStore2::INotification {


### PR DESCRIPTION
Reason for change:
RDKEMW-2483: Out of range values are accepted by org.rdk.UserSettings.setVoiceGuidanceRate api.
RDK-56276: Updated version numbers and changelog.md and documentation

Test Procedure: Make full stack build and verify user settings setVoiceGuidanceRate api.
https://etwiki.sys.comcast.net/display/RDKV/User+Settings+Inspector

Risks: Low
Priority: P1