### PR TITLE
RDKEMW-2521: Add onDisconnected event support

### DIFF
--- a/RDKWindowManager/RDKWindowManager.h
+++ b/RDKWindowManager/RDKWindowManager.h
@@ -72,6 +72,12 @@ namespace WPEFramework {
                         Exchange::JRDKWindowManager::Event::OnUserInactivity(_parent, minutes);
                     }
 
+                    void OnDisconnected(const std::string& client) override
+                    {
+                        LOGINFO("OnDisconnected");
+                        Exchange::JRDKWindowManager::Event::OnDisconnected(_parent, client);
+                    }
+
                 private:
                     RDKWindowManager& _parent;
             };

--- a/RDKWindowManager/RDKWindowManagerImplementation.cpp
+++ b/RDKWindowManager/RDKWindowManagerImplementation.cpp
@@ -396,6 +396,20 @@ void RDKWindowManagerImplementation::RdkWindowManagerListener::onUserInactive(co
     }
 }
 
+void RDKWindowManagerImplementation::RdkWindowManagerListener::onApplicationDisconnected(const std::string& client)
+{
+    LOGINFO("RDKWindowManager onApplicationDisconnected event received for client: %s", client.c_str());
+
+    if (nullptr == mRDKWindowManagerImpl)
+    {
+        LOGERR("mRDKWindowManagerImpl is null");
+    }
+    else
+    {
+        mRDKWindowManagerImpl->dispatchEvent(RDKWindowManagerImplementation::Event::RDK_WINDOW_MANAGER_EVENT_APPLICATION_DISCONNECTED, JsonValue(client));
+    }
+}
+
 void RDKWindowManagerImplementation::dispatchEvent(Event event, const JsonValue &params)
 {
     Core::IWorkerPool::Instance().Submit(Job::Create(this, event, params));
@@ -417,6 +431,16 @@ void RDKWindowManagerImplementation::Dispatch(Event event, const JsonValue param
                  ++index;
              }
          break;
+
+        case RDK_WINDOW_MANAGER_EVENT_APPLICATION_DISCONNECTED:
+            while (index != mRDKWindowManagerNotification.end())
+            {
+                LOGINFO("RDKWindowManager Dispatch OnDisconnected client: %s", params.String().c_str());
+
+                (*index)->OnDisconnected(params.String());
+                ++index;
+            }
+            break;
 
          default:
              LOGWARN("Event[%u] not handled", event);

--- a/RDKWindowManager/RDKWindowManagerImplementation.h
+++ b/RDKWindowManager/RDKWindowManagerImplementation.h
@@ -71,7 +71,8 @@ namespace Plugin {
     public:
         enum Event {
                 RDK_WINDOW_MANAGER_EVENT_UNKNOWN,
-                RDK_WINDOW_MANAGER_EVENT_ON_USER_INACTIVITY
+                RDK_WINDOW_MANAGER_EVENT_ON_USER_INACTIVITY,
+                RDK_WINDOW_MANAGER_EVENT_APPLICATION_DISCONNECTED
             };
 
         class EXTERNAL Job : public Core::IDispatch {
@@ -169,6 +170,7 @@ namespace Plugin {
 
             /* Events listeners */
             virtual void onUserInactive(const double minutes);
+            virtual void onApplicationDisconnected(const std::string& client);
 
           private:
               RDKWindowManagerImplementation *mRDKWindowManagerImpl;


### PR DESCRIPTION
Reason for change : onDisconnect event support
in RDKWindowManager
Test Procedure: Event is dispatched when a disconnection occurs Risks: Low
Priority: P1
Signed-off-by: Pavithra V pavviswa@synamedia.com