### PR TITLE
RDK-57093: Update Plugin Clients to use update Power manager interface

### DIFF
--- a/Telemetry/TelemetryImplementation.cpp
+++ b/Telemetry/TelemetryImplementation.cpp
@@ -383,7 +383,7 @@ namespace Plugin {
         }
     }
 
-    void TelemetryImplementation::onPowerModeChanged(const PowerState &currentState, const PowerState &newState)
+    void TelemetryImplementation::onPowerModeChanged(const PowerState currentState, const PowerState newState)
     {
         JsonObject params;
 

--- a/Telemetry/TelemetryImplementation.h
+++ b/Telemetry/TelemetryImplementation.h
@@ -51,7 +51,7 @@ namespace Plugin {
                 ~PowerManagerNotification() override = default;
 
             public:
-                void OnPowerModeChanged(const PowerState &currentState, const PowerState &newState) override
+                void OnPowerModeChanged(const PowerState currentState, const PowerState newState) override
                 {
                     _parent.onPowerModeChanged(currentState, newState);
                 }
@@ -142,7 +142,7 @@ namespace Plugin {
         Core::hresult AbortReport() override;
 
         void InitializePowerManager();
-        void onPowerModeChanged(const PowerState &currentState, const PowerState &newState);
+        void onPowerModeChanged(const PowerState currentState, const PowerState newState);
         void registerEventHandlers();
 
         // IConfiguration interface


### PR DESCRIPTION
Reason for change: Interface API arguments should not be passed by reference if they are primitive data types.
Test Procedure: SetPowerState & QueryPowerState sanity
Risks: LOW