### PR TITLE
RDKEMW-4107: Missing additionalMetadata in IPackageImpl.Install

### DIFF
--- a/AppManager/AppManagerImplementation.cpp
+++ b/AppManager/AppManagerImplementation.cpp
@@ -370,7 +370,8 @@ Core::hresult AppManagerImplementation::packageLock(const string& appId, Package
                     }
                     if ((nullptr != mPackageManagerHandlerObject) && (!packageData.version.empty()))
                     {
-                        status = mPackageManagerHandlerObject->Lock(appId, packageData.version, lockReason, packageData.lockId, packageData.unpackedPath, packageData.configMetadata, packageData.appMetadata );
+                        Exchange::RuntimeConfig runtimeConfig;
+                        status = mPackageManagerHandlerObject->Lock(appId, packageData.version, lockReason, packageData.lockId, packageData.unpackedPath, runtimeConfig, packageData.appMetadata );
                         if(status == Core::ERROR_NONE)
                         {
                             LOGINFO("Fetching package entry updated for appId: %s " \


### PR DESCRIPTION
AppManager changes are committed in lifecycle2.0 branch.  I made a quick fix for the build issue.