### PR TITLE
RDKEMW-4138:Coverity integration with Entservices-infra repo

### DIFF
--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -112,6 +112,9 @@ mkdir -p headers/ccec/drivers
 mkdir -p headers/network
 mkdir -p headers/proc
 mkdir -p headers/libusb
+mkdir -p headers/Dobby
+mkdir -p headers/Dobby/Public/Dobby
+mkdir -p headers/Dobby/IpcService
 echo "dir created successfully"
 echo "======================================================================================"
 
@@ -164,6 +167,10 @@ touch audioOutputPortType.hpp
 touch audioOutputPortConfig.hpp
 touch tr181api.h
 touch dsRpc.h
+touch Dobby/DobbyProtocol.h
+touch Dobby/DobbyProxy.h
+touch Dobby/Public/Dobby/IDobbyProxy.h
+touch Dobby/IpcService/IpcFactory.h
 echo "files created successfully"
 echo "======================================================================================"
 

--- a/cov_build.sh
+++ b/cov_build.sh
@@ -23,6 +23,8 @@ cmake -G Ninja -S "$GITHUB_WORKSPACE" -B build/entservices-infra \
 -DDS_FOUND=ON \
 -DPLUGIN_USBDEVICE=ON \
 -DPLUGIN_USB_MASS_STORAGE=ON \
+-DPLUGIN_OCICONTAINER=ON \
+-DPLUGIN_TELEMETRY=ON \
 -DCMAKE_CXX_FLAGS="-DEXCEPTIONS_ENABLE=ON \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/audiocapturemgr \
@@ -32,6 +34,9 @@ cmake -G Ninja -S "$GITHUB_WORKSPACE" -B build/entservices-infra \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/ccec/drivers \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/network \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/libusb \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/Dobby \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/Dobby/Public/Dobby \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/Dobby/IpcService \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/devicesettings.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/Iarm.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/Rfc.h \
@@ -42,6 +47,11 @@ cmake -G Ninja -S "$GITHUB_WORKSPACE" -B build/entservices-infra \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/maintenanceMGR.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/secure_wrappermock.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/libusb/libusb.h \
+-include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/Dobby.h \
+-include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/Dobby/DobbyProtocol.h \
+-include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/Dobby/DobbyProxy.h \
+-include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/Dobby/Public/Dobby/IDobbyProxy.h \
+-include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/Dobby/IpcService/IpcFactory.h \
 --coverage -Wall -Werror -Wno-error=format \
 -Wl,-wrap,system -Wl,-wrap,popen -Wl,-wrap,syslog \
 -DENABLE_TELEMETRY_LOGGING -DUSE_IARMBUS \


### PR DESCRIPTION
Reason for change: Coverity integration with middleware component workflow 
Test Procedure: Verify checks in github
Risks: Low
Signed-off-by:AkshayKumar_Gampa <AkshayKumar_Gampa@comcast.com>