### PR TITLE
RDKEMW-4311:[AI2.0][LM]  Changes required for target lifecycle state Active and suspended

### DIFF
--- a/LifecycleManager/LifecycleManagerImplementation.cpp
+++ b/LifecycleManager/LifecycleManagerImplementation.cpp
@@ -138,7 +138,7 @@ namespace WPEFramework
                      handleStateChangeEvent(obj);
                      while (index != mLifecycleManagerNotification.end())
                      {
-                         (*index)->OnAppStateChanged(appId, (LifecycleState)oldLifecycleState, errorReason);
+                         (*index)->OnAppStateChanged(appId, (LifecycleState)newLifecycleState, errorReason);
                          ++index;
                      }
                      while (stateNotificationIndex != mLifecycleManagerStateNotification.end())
@@ -226,7 +226,7 @@ namespace WPEFramework
             // Notifies appropriate API Gateway when an app is about to be loaded
             // Lifecycle manager will create the appInstanceId once the app is loaded.  Ripple is responsible for creating a token. 
             Core::hresult status = Core::ERROR_NONE;
-            ApplicationContext* context = getContext(appId, "");
+            ApplicationContext* context = getContext("", appId);
             bool firstLaunch = false;
             if (nullptr == context)
 	    {

--- a/LifecycleManager/State.cpp
+++ b/LifecycleManager/State.cpp
@@ -113,8 +113,9 @@ namespace WPEFramework
         bool SuspendedState::handle(string& errorReason)
 	{
 	    bool ret = false;
-            ApplicationContext* context = getContext();
-            sem_wait(&context->mAppReadySemaphore);
+            //TODO : Remove wait for now
+            //ApplicationContext* context = getContext();
+            //sem_wait(&context->mAppReadySemaphore);
             RuntimeManagerHandler* runtimeManagerHandler = RequestHandler::getInstance()->getRuntimeManagerHandler();
 	    if (nullptr != runtimeManagerHandler)
 	    {


### PR DESCRIPTION
Reason for change : Fixed lifecycle state change, Correction in SpawnApp getContext() paramter interchanged, remove SuspendedState sem_wait
Test Procedure: NA
Risks: Low
Priority: P1
Signed-off-by: Siva Thandayuthapani [sithanda@synamedia.com](mailto:sithanda@synamedia.com)