### PR TITLE
RDKEMW-3885-4159: Launch state set with events

### DIFF
--- a/AppManager/LifecycleInterfaceConnector.h
+++ b/AppManager/LifecycleInterfaceConnector.h
@@ -84,6 +84,7 @@ namespace WPEFramework
                     string GetAppInstanceId(const string& appId) const;
                     void RemoveApp(const string& appId);
                     Core::hresult isAppLoaded(const string& appId, bool& loaded);
+                    bool fileExists(const char* pFileName);
 
                 private:
                     mutable Core::CriticalSection mAdminLock;


### PR DESCRIPTION
Reason For change: Ensure proper state is set on launch
                   support packageinstallation methods and events
Test Procedure: verified with json rpc curl command Risks: Medium
Priority: P1
Signed-off-by: Madhumathi R bp-mbhand796@cable.comcast.com