### PR TITLE
RDK-57747: Added L1 and L2 test cases for content pin property

### DIFF
--- a/Tests/L1Tests/tests/test_UserSettings.cpp
+++ b/Tests/L1Tests/tests/test_UserSettings.cpp
@@ -641,6 +641,37 @@ TEST_F(UserSettingsTest, GetVoiceGuidanceHints_Success)
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getVoiceGuidanceHints"), _T("{}"), response));
 }
+
+TEST_F(UserSettingsTest, SetContentPin_Failure)
+{
+    EXPECT_CALL(*p_store2Mock, SetValue(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(Core::ERROR_GENERAL));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setContentPin"), _T("{}"), response));
+}
+
+TEST_F(UserSettingsTest, SetContentPin_Success)
+{
+    EXPECT_CALL(*p_store2Mock, SetValue(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(Core::ERROR_NONE));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setContentPin"), _T("{}"), response));
+}
+
+TEST_F(UserSettingsTest, GetContentPin_Failure)
+{
+    EXPECT_CALL(*p_store2Mock, GetValue(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(Core::ERROR_GENERAL));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getContentPin"), _T("{}"), response));
+}
+
+TEST_F(UserSettingsTest, GetContentPin_Success)
+{
+    EXPECT_CALL(*p_store2Mock, GetValue(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(Core::ERROR_NONE));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getContentPin"), _T("{}"), response));
+}
+
 TEST_F(UserSettingsTest, GetMigrationState_Failure)
 {
     EXPECT_CALL(*p_store2Mock, GetValue(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))

--- a/Tests/L2Tests/tests/UserSettings_L2Test.cpp
+++ b/Tests/L2Tests/tests/UserSettings_L2Test.cpp
@@ -1283,7 +1283,7 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     EXPECT_TRUE(result_bool.Value());
     paramsMigrationState.Clear();
 
-    paramsMigrationState["key"] = "CONTENT_PIN_CHANGED";
+    paramsMigrationState["key"] = "CONTENT_PIN";
     status = InvokeServiceMethod("org.rdk.UserSettings", "getContentPin", paramsMigrationState, result_bool);
     EXPECT_EQ(status, Core::ERROR_NONE);
     EXPECT_TRUE(result_bool.Value());
@@ -1878,7 +1878,7 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     EXPECT_FALSE(result_bool.Value());
     paramsMigrationState.Clear();
 
-    paramsMigrationState["key"] = "CONTENT_PIN_CHANGED";
+    paramsMigrationState["key"] = "CONTENT_PIN";
     status = InvokeServiceMethod("org.rdk.UserSettings", "getContentPin", paramsMigrationState, result_bool);
     EXPECT_EQ(status, Core::ERROR_NONE);
     EXPECT_FALSE(result_bool.Value());
@@ -2616,7 +2616,7 @@ TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
 
-                status = m_usersettings_inspe_plugin->GetMigrationState(Exchange::IUserSettingsInspector::SettingsKey::CONTENT_PIN_CHANGED, requiresMigration);
+                status = m_usersettings_inspe_plugin->GetMigrationState(Exchange::IUserSettingsInspector::SettingsKey::CONTENT_PIN , requiresMigration);
                 EXPECT_EQ(requiresMigration, false);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)

--- a/Tests/L2Tests/tests/UserSettings_L2Test.cpp
+++ b/Tests/L2Tests/tests/UserSettings_L2Test.cpp
@@ -731,425 +731,6 @@ MATCHER_P(MatchRequestStatusDouble, expected, "")
 
 }
 
-/* Activating UserSettings and Persistent store plugins and UserSettings namespace has no entries in db.
-   So that we can verify whether UserSettings plugin is receiving default values from PersistentStore or not*/
-TEST_F(UserSettingTest, VerifyDefaultValues)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    uint32_t signalled = UserSettings_StateInvalid;
-    Core::Sink<NotificationHandler> notification;
-    bool defaultBooleanValue = true;
-    string defaultStrValue = "eng";
-    double defaultDoubleValue;
-
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid Client_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetAudioDescription(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetPreferredAudioLanguages(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetPresentationLanguage(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetCaptions(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultStrValue should get "AUTO" and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetPreferredClosedCaptionService(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "AUTO");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetPinControl(defaultBooleanValue);
-                 EXPECT_EQ(defaultBooleanValue, false);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-
-                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetViewingRestrictions(defaultStrValue);
-                 EXPECT_EQ(defaultStrValue, "");
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetViewingRestrictionsWindow(defaultStrValue);
-                 EXPECT_EQ(defaultStrValue, "");
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetLiveWatershed(defaultBooleanValue);
-                 EXPECT_EQ(defaultBooleanValue, false);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetPlaybackWatershed(defaultBooleanValue);
-                 EXPECT_EQ(defaultBooleanValue, false);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetBlockNotRatedContent(defaultBooleanValue);
-                 EXPECT_EQ(defaultBooleanValue, false);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetPinOnPurchase(defaultBooleanValue);
-                 EXPECT_EQ(defaultBooleanValue, false);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetHighContrast(defaultBooleanValue);
-                 EXPECT_EQ(defaultBooleanValue, false);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetVoiceGuidance(defaultBooleanValue);
-                 EXPECT_EQ(defaultBooleanValue, false);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultDoubleValue should get '1' and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetVoiceGuidanceRate(defaultDoubleValue);
-                 EXPECT_EQ(defaultDoubleValue, 1);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetVoiceGuidanceHints(defaultBooleanValue);
-                 EXPECT_EQ(defaultBooleanValue, false);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->GetContentPin(defaultStrValue);
-                 EXPECT_EQ(defaultStrValue, "");
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 /* Setting Audio Description value as true.So UserSettings namespace has one entry in db.
-                 But we are trying to get PreferredAudioLanguages, which has no entry in db.
-                 So GetPreferredAudioLanguages should return the empty string and the return status
-                 from Persistant store is  Core::ERROR_UNKNOWN_KEY and return status from usersettings is Core::ERROR_NONE */
-                 status = m_usersettingsplugin->SetAudioDescription(defaultBooleanValue);
-                 EXPECT_EQ(status,Core::ERROR_NONE);
-                 if (status != Core::ERROR_NONE)
-                 {
-                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                     TEST_LOG("Err: %s", errorMsg.c_str());
-                 }
-
-                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onAudioDescriptionChanged);
-                 EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
-
-                 /* We are trying to get PreferredAudioLanguages, which has no entry in db.
-                 Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
-                 GetPreferredAudioLanguages should get the empty string.*/
-                status = m_usersettingsplugin->GetPreferredAudioLanguages(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* We are trying to get PresentationLanguage, which has no entry in db.
-                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
-                GetPreferredAudioLanguages should get the empty string.*/
-                status = m_usersettingsplugin->GetPresentationLanguage(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* We are trying to get Captions, which has no entry in db.
-                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
-                GetPreferredAudioLanguages should get the empty string.*/
-                status = m_usersettingsplugin->GetCaptions(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* We are trying to get PreferredCaptionsLanguages, which has no entry in db.
-                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
-                GetPreferredAudioLanguages should get the empty string.*/
-                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* We are trying to get PreferredClosedCaptionService, which has no entry in db.
-                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
-                GetPreferredAudioLanguages should get the empty string.*/
-                status = m_usersettingsplugin->GetPreferredClosedCaptionService(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "AUTO");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetPinControl(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetViewingRestrictions(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetViewingRestrictionsWindow(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetLiveWatershed(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetPlaybackWatershed(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetBlockNotRatedContent(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetPinOnPurchase(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetHighContrast(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetVoiceGuidance(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultDoubleValue should get '1' and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetVoiceGuidanceRate(defaultDoubleValue);
-                EXPECT_EQ(defaultDoubleValue, 1);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetVoiceGuidanceHints(defaultBooleanValue);
-                EXPECT_EQ(defaultBooleanValue, false);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
-                status = m_usersettingsplugin->GetContentPin(defaultStrValue);
-                EXPECT_EQ(defaultStrValue, "");
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("m_usersettingsplugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}
-
-
 TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
 {
     JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
@@ -1284,7 +865,7 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     paramsMigrationState.Clear();
 
     paramsMigrationState["key"] = "CONTENT_PIN";
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getContentPin", paramsMigrationState, result_bool);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getMigrationState", paramsMigrationState, result_bool);
     EXPECT_EQ(status, Core::ERROR_NONE);
     EXPECT_TRUE(result_bool.Value());
     paramsMigrationState.Clear();
@@ -1879,7 +1460,7 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     paramsMigrationState.Clear();
 
     paramsMigrationState["key"] = "CONTENT_PIN";
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getContentPin", paramsMigrationState, result_bool);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getMigrationState", paramsMigrationState, result_bool);
     EXPECT_EQ(status, Core::ERROR_NONE);
     EXPECT_FALSE(result_bool.Value());
     paramsMigrationState.Clear();
@@ -1887,6 +1468,424 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     status = InvokeServiceMethod("org.rdk.UserSettings", "getMigrationStates", paramsMigrationState, result_json);
     EXPECT_EQ(status, Core::ERROR_NONE);
 
+}
+
+/* Activating UserSettings and Persistent store plugins and UserSettings namespace has no entries in db.
+   So that we can verify whether UserSettings plugin is receiving default values from PersistentStore or not*/
+TEST_F(UserSettingTest, VerifyDefaultValues)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    uint32_t signalled = UserSettings_StateInvalid;
+    Core::Sink<NotificationHandler> notification;
+    bool defaultBooleanValue = true;
+    string defaultStrValue = "eng";
+    double defaultDoubleValue;
+
+    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
+    {
+        TEST_LOG("Invalid Client_UserSettings");
+    }
+    else
+    {
+        ASSERT_TRUE(m_controller_usersettings!= nullptr);
+        if (m_controller_usersettings)
+        {
+            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
+            if (m_usersettingsplugin)
+            {
+                m_usersettingsplugin->AddRef();
+                m_usersettingsplugin->Register(&notification);
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetAudioDescription(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPreferredAudioLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPresentationLanguage(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetCaptions(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "AUTO" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPreferredClosedCaptionService(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "AUTO");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetPinControl(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+
+                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetViewingRestrictions(defaultStrValue);
+                 EXPECT_EQ(defaultStrValue, "");
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetViewingRestrictionsWindow(defaultStrValue);
+                 EXPECT_EQ(defaultStrValue, "");
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetLiveWatershed(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetPlaybackWatershed(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetBlockNotRatedContent(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetPinOnPurchase(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetHighContrast(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetVoiceGuidance(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultDoubleValue should get '1' and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetVoiceGuidanceRate(defaultDoubleValue);
+                 EXPECT_EQ(defaultDoubleValue, 1);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetVoiceGuidanceHints(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetContentPin(defaultStrValue);
+                 EXPECT_EQ(defaultStrValue, "");
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* Setting Audio Description value as true.So UserSettings namespace has one entry in db.
+                 But we are trying to get PreferredAudioLanguages, which has no entry in db.
+                 So GetPreferredAudioLanguages should return the empty string and the return status
+                 from Persistant store is  Core::ERROR_UNKNOWN_KEY and return status from usersettings is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->SetAudioDescription(defaultBooleanValue);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onAudioDescriptionChanged);
+                 EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
+
+                 /* We are trying to get PreferredAudioLanguages, which has no entry in db.
+                 Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                 GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPreferredAudioLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get PresentationLanguage, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPresentationLanguage(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get Captions, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetCaptions(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get PreferredCaptionsLanguages, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get PreferredClosedCaptionService, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPreferredClosedCaptionService(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "AUTO");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPinControl(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetViewingRestrictions(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetViewingRestrictionsWindow(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetLiveWatershed(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPlaybackWatershed(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetBlockNotRatedContent(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPinOnPurchase(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetHighContrast(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetVoiceGuidance(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultDoubleValue should get '1' and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetVoiceGuidanceRate(defaultDoubleValue);
+                EXPECT_EQ(defaultDoubleValue, 1);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetVoiceGuidanceHints(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetContentPin(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                m_usersettingsplugin->Unregister(&notification);
+                m_usersettingsplugin->Release();
+            }
+            else
+            {
+                TEST_LOG("m_usersettingsplugin is NULL");
+            }
+            m_controller_usersettings->Release();
+        }
+        else
+        {
+            TEST_LOG("m_controller_usersettings is NULL");
+        }
+    }
 }
 
 TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)

--- a/UserSettings/CHANGELOG.md
+++ b/UserSettings/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.3.0] - 2025-05-27
+### Added
+- Add "contentPin" parameter in User Settings.
+
 ## [2.2.0] - 2025-02-18
 ### Added
 - Add user settings inspector interface to user settings plugin.

--- a/UserSettings/UserSettings.cpp
+++ b/UserSettings/UserSettings.cpp
@@ -20,7 +20,7 @@
 #include "UserSettings.h"
 
 #define API_VERSION_NUMBER_MAJOR 2
-#define API_VERSION_NUMBER_MINOR 2
+#define API_VERSION_NUMBER_MINOR 3
 #define API_VERSION_NUMBER_PATCH 0
 
 namespace WPEFramework

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -128,9 +128,11 @@ UserSettingsImplementation* UserSettingsImplementation::instance(UserSettingsImp
 
 UserSettingsImplementation::~UserSettingsImplementation()
 {
+    LOGINFO("UserSettingsImplementation Destructor");
     if(_remotStoreObject)
     {
         _remotStoreObject->Release();
+        _remotStoreObject = nullptr;
     }
     if (_service != nullptr)
     {
@@ -1021,6 +1023,7 @@ Core::hresult UserSettingsImplementation::GetMigrationStates(IUserSettingsMigrat
     {
         for (auto uimap = _userSettingsInspectorMap.begin(); uimap != _userSettingsInspectorMap.end(); uimap++)
         {
+            value.assign("");
             LOGINFO("Property [%s] value is fetching...", (uimap->second).c_str());
             status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, uimap->second, value, ttl);
             LOGINFO("value[%s] status[%d]", value.c_str(), status);


### PR DESCRIPTION
Reason for change: Added L1 and L2 tests for new property content Pin in User settings.
Test Procedure: Run L1 and L2 test yml files and verify all test cases are passing.

Risks: NO
Priority: P1