### PR TITLE
RDKEMW-4159 : Fix to not lock during Suspend state

### DIFF
--- a/AppManager/AppManagerImplementation.cpp
+++ b/AppManager/AppManagerImplementation.cpp
@@ -467,7 +467,7 @@ Core::hresult AppManagerImplementation::packageLock(const string& appId, Package
     if ((status == Core::ERROR_NONE) &&
         (!loaded ||
          it == mAppInfo.end() ||
-         it->second.appNewState != Exchange::IAppManager::AppLifecycleState::APP_STATE_SUSPENDED || it->second.appNewState != Exchange::IAppManager::AppLifecycleState::APP_STATE_PAUSED || it->second.appNewState != Exchange::IAppManager::AppLifecycleState::APP_STATE_HIBERNATED))
+         (it->second.appNewState != Exchange::IAppManager::AppLifecycleState::APP_STATE_SUSPENDED && it->second.appNewState != Exchange::IAppManager::AppLifecycleState::APP_STATE_PAUSED && it->second.appNewState != Exchange::IAppManager::AppLifecycleState::APP_STATE_HIBERNATED)))
     {
          /* Fetch list of installed packages */
         status = fetchInstalledPackages(packageList);


### PR DESCRIPTION
Reason For change: Fix to not lock during Suspend/Paused/Hibernate state
Test Procedure: verified with json rpc curl command Risks: Medium
Priority: P1
Signed-off-by: Madhumathi R bp-mbhand796@cable.comcast.com