### PR TITLE
RDKEMW-3788: Add WhoAmI support to DeviceProvisioning (entservices-in…

### DIFF
--- a/Analytics/Implementation/Backend/Sift/SiftConfig.h
+++ b/Analytics/Implementation/Backend/Sift/SiftConfig.h
@@ -141,6 +141,7 @@ namespace WPEFramework
                 void AuthTokenChanged() override {}
                 void SessionTokenChanged() override {}
                 void ServiceAccessTokenChanged() override {}
+                void OnPartnerIdChanged(const string& oldPartnerId, const string& newPartnerId, const bool isNew) override {}
 
                 void RegisterActivationStatusCallback(Callback callback) { mActivationStatusCallback = callback; }
 


### PR DESCRIPTION
…fra)

Reason for change: missing WAI support in RDK-E
Test Procedure: described in the ticket
Implements: code changes in AuthService and DeviceProvisioning
Risks: No
Source: COMCAST
License: Apache-2.0
Upstream-Status: Pending