### PR TITLE
RDKEMW-3893: Ensure proper states are set

### DIFF
--- a/AppManager/LifecycleInterfaceConnector.h
+++ b/AppManager/LifecycleInterfaceConnector.h
@@ -36,7 +36,7 @@
 #include <interfaces/ILifecycleManager.h>
 #include <interfaces/ILifecycleManagerState.h>
 #include <interfaces/IAppManager.h>
-
+#include <condition_variable>
 
 namespace WPEFramework
 {
@@ -92,6 +92,9 @@ namespace WPEFramework
                     Exchange::ILifecycleManagerState *mLifecycleManagerStateRemoteObject;
                     Core::Sink<NotificationHandler> mNotification;
                     PluginHost::IShell* mCurrentservice;
+                    std::condition_variable mStateChangedCV;
+                    std::mutex mStateMutex;
+                    std::string mAwaitedAppId;
         };
     }
 }

--- a/LifecycleManager/State.cpp
+++ b/LifecycleManager/State.cpp
@@ -211,4 +211,4 @@ namespace WPEFramework
             return success;
         }
     }
-} /* namespa
+} /* namespace WPEFramework */

--- a/LifecycleManager/State.cpp
+++ b/LifecycleManager/State.cpp
@@ -206,8 +206,9 @@ namespace WPEFramework
                 }
                 //TODO: handle return properly
                 success = true;
-      }
-      //TODO: handle return properly
-	    return success;
-	}
-} /* namespace WPEFramework */
+            }
+            //TODO: handle return properly	
+            return success;
+        }
+    }
+} /* namespa

--- a/LifecycleManager/State.cpp
+++ b/LifecycleManager/State.cpp
@@ -204,9 +204,11 @@ namespace WPEFramework
                 {
                     success = runtimeManagerHandler->terminate(context->getAppInstanceId(), errorReason);
                 }
+                //TODO: handle return properly
+                success = true;
             }
-            return success;
-	}
 
-    } /* namespace Plugin */
+           //TODO: handle return properly
+	    return success;
+	}
 } /* namespace WPEFramework */

--- a/PackageManager/PackageManagerImplementation.cpp
+++ b/PackageManager/PackageManagerImplementation.cpp
@@ -665,7 +665,7 @@ namespace Plugin {
         #ifdef USE_LIBPACKAGE
         packagemanager::ConfigMetadataArray aConfigMetadata;
         packagemanager::Result pmResult = packageImpl->Initialize(configStr, aConfigMetadata);
-        LOGDBG("aConfigMetadata.count:%ld pmResult=%d", aConfigMetadata.size(), pmResult);
+        LOGDBG("aConfigMetadata.count:%d pmResult=%d", aConfigMetadata.size(), pmResult);
         for (auto it = aConfigMetadata.begin(); it != aConfigMetadata.end(); ++it ) {
             StateKey key = it->first;
             State state(it->second);


### PR DESCRIPTION
Reason for change : Setting proper states on deactivate/resume
Test Procedure: Verified using curl cmds
Risks: Medium
Priority: P1
Signed-off-by: Pavithra V bp-pviswa149@cable.comcast.com