### PR TITLE
RDKEMW-4461: [RDKE][XUMO] - Device not auto mounting at bootup.

### DIFF
--- a/USBMassStorage/USBMassStorageImplementation.cpp
+++ b/USBMassStorage/USBMassStorageImplementation.cpp
@@ -65,6 +65,9 @@ namespace Plugin {
             if (_remoteUSBDeviceObject != nullptr)
             {
                 registerEventHandlers();
+
+		/* Getting USB Device list and mounting available USB devices */
+                MountDevicesOnBootUp();
             }
             else
             {


### PR DESCRIPTION
Reason for change:
RDKEMW-4461: [RDKE][XUMO] - Device not auto mounting USB (or detecting USB) when plugged-in USB after launching USB tile.

Test Procedure:
Create full stack build and verify that the usb mounting at the bootup time or not. Run lsblk command.

Risks: High
Priority: P1