### PR TITLE
RDKEMW-5966: Handle injectKey requests in task queue to reduce latency

### DIFF
--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include <mutex>
-#include <future>
 #include "Module.h"
 #include <rdkshell/rdkshellevents.h>
 #include <rdkshell/rdkshell.h>
@@ -467,24 +466,20 @@ namespace WPEFramework {
                 std::vector<ICapture::IStore *>mCaptureStorers;
             };
 
-            class KeyEventQueue {
+            class TaskQueue {
             public:
-                struct KeyEvent {
-                    uint32_t keyCode;
-                    uint32_t flags;
-                    std::promise<bool> resultPromise;
-                };
+                using Task = std::function<void(void)>;
             public:
-                KeyEventQueue() = default;
-                ~KeyEventQueue() = default;
-                KeyEventQueue(const KeyEventQueue&) = delete;
-                KeyEventQueue& operator=(const KeyEventQueue&) = delete;
+                TaskQueue() = default;
+                ~TaskQueue() = default;
+                TaskQueue(const TaskQueue&) = delete;
+                TaskQueue& operator=(const TaskQueue&) = delete;
 
-                void push(KeyEvent&& event);
-                bool pop(KeyEvent& outEvent);
+                void push(Task task);
+                bool pop(Task& outTask);
             private:
-                std::queue<KeyEvent> m_queue;
-                std::mutex m_mutex;
+                std::queue<Task> mQueue;
+                std::mutex mMutex;
             };
 
         private/*members*/:
@@ -501,7 +496,7 @@ namespace WPEFramework {
             bool mEnableEasterEggs;
             ScreenCapture mScreenCapture;
             bool mErmEnabled;
-            KeyEventQueue m_keyEventQueue;
+            TaskQueue mTaskQueue;
 #ifdef ENABLE_RIALTO_FEATURE
         std::shared_ptr<RialtoConnector>  rialtoConnector;
 #endif //ENABLE_RIALTO_FEATURE

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <mutex>
+#include <future>
 #include "Module.h"
 #include <rdkshell/rdkshellevents.h>
 #include <rdkshell/rdkshell.h>
@@ -466,6 +467,26 @@ namespace WPEFramework {
                 std::vector<ICapture::IStore *>mCaptureStorers;
             };
 
+            class KeyEventQueue {
+            public:
+                struct KeyEvent {
+                    uint32_t keyCode;
+                    uint32_t flags;
+                    std::promise<bool> resultPromise;
+                };
+            public:
+                KeyEventQueue() = default;
+                ~KeyEventQueue() = default;
+                KeyEventQueue(const KeyEventQueue&) = delete;
+                KeyEventQueue& operator=(const KeyEventQueue&) = delete;
+
+                void push(KeyEvent&& event);
+                bool pop(KeyEvent& outEvent);
+            private:
+                std::queue<KeyEvent> m_queue;
+                std::mutex m_mutex;
+            };
+
         private/*members*/:
             bool mRemoteShell;
             bool mEnableUserInactivityNotification;
@@ -480,6 +501,7 @@ namespace WPEFramework {
             bool mEnableEasterEggs;
             ScreenCapture mScreenCapture;
             bool mErmEnabled;
+            KeyEventQueue m_keyEventQueue;
 #ifdef ENABLE_RIALTO_FEATURE
         std::shared_ptr<RialtoConnector>  rialtoConnector;
 #endif //ENABLE_RIALTO_FEATURE


### PR DESCRIPTION
When `RDKSHELL_FRAMERATE` is set to 60, the loop inside `shellThread` is locking the `gRdkShellMutex` more frequently, potentially leading to live-lock of injectKey handling. 

This manifests as an increased response time of injectKey API call, compared to `RDKSHELL_FRAMERATE=30`, which can reach several seconds.