### PR TITLE
RDKEMW-3106 : Ensure modules path works in all environments

### DIFF
--- a/NativeJS/NativeJSImplementation.cpp
+++ b/NativeJS/NativeJSImplementation.cpp
@@ -58,7 +58,7 @@ namespace WPEFramework
                 //}
 		
 		mNativeJSRenderer->run();
-		
+		setenv("JSRUNTIME_MODULES_PATH","/home/root/modules/",1);
 		printf("After launch application execution ... \n"); fflush(stdout);
 		mNativeJSRenderer.reset();
 


### PR DESCRIPTION
Reason for change: Addressed modules path error
Test Procedure: build should be successful.
Risks: low
Priority: P2