### PR TITLE
RDKEMW-6487 : [entservices-testframework] L2-infra test failing due to reason : unable to find include file "omi_proxy.hpp"

### DIFF
--- a/.github/workflows/L2-tests.yml
+++ b/.github/workflows/L2-tests.yml
@@ -415,6 +415,7 @@ jobs:
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/libusb
           -I $GITHUB_WORKSPACE/install/usr/include
           -I $GITHUB_WORKSPACE/build/mocks
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/Dobby
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/Dobby/Public/Dobby
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/Dobby/IpcService


### PR DESCRIPTION
RDKEMW-6487 : [entservices-testframework] L2-infra test failing due to reason : unable to find include file "omi_proxy.hpp"
Procedure : Run L2Test to verify
Risk : Medium