### PR TITLE
RDKEMW-6875: adopt AddRef() change

### DIFF
--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -453,8 +453,9 @@ namespace WPEFramework {
                 INTERFACE_ENTRY(Exchange::ICapture)
                 END_INTERFACE_MAP
 
-                virtual void AddRef() const {}
-                virtual uint32_t Release() const { return 0; }
+                virtual uint32_t AddRef() const override { return 0; }
+                virtual uint32_t Release() const override { return 0; }
+
                 virtual const TCHAR* Name() const override { return "ScreenCapture"; }
 
                 virtual bool Capture(ICapture::IStore& storer) override;


### PR DESCRIPTION
Reason for Change: https://github.com/rdkcentral/entservices-infra/compare/1.7.0...1.7.1
where plugin interface builder got some change in `AddRef()` and RDKShell plugin was never adopted to that change.
Updated to match that.