### PR TITLE
RDKEMW-6934: [RDKEMW-6935] [RDKEMW-6785] [RDKE][Rack][Element/Sky]: WPEFramework crash.

### DIFF
--- a/USBDevice/USBDeviceImplementation.cpp
+++ b/USBDevice/USBDeviceImplementation.cpp
@@ -157,8 +157,6 @@ void USBDeviceImplementation::libUSBClose(void)
     (void)libusb_hotplug_deregister_callback(NULL, _hotPlugHandle[0]);
     (void)libusb_hotplug_deregister_callback(NULL, _hotPlugHandle[1]);
 
-    (void)libusb_exit(NULL);
-
     if (_libUSBDeviceThread)
     {
         if (_libUSBDeviceThread->joinable())
@@ -169,6 +167,7 @@ void USBDeviceImplementation::libUSBClose(void)
         _libUSBDeviceThread = nullptr;
     }
 
+    (void)libusb_exit(NULL);
     LOGINFO("libUSBClose Successed");
 }
 


### PR DESCRIPTION
Reason for change:
 WPEFramework crashwith signature WPEFramework::Plugin::USBDeviceImplementation::libUSBEventsHandlingThread with fingerprint 14820164 during Reboot testing.
[RDKMW][RTK-XIONE] WPEFramework crash Observed while Launching and Playing XUMO Play.

Test Procedure:
Reboot testing needs to do. No. of Reboots: Atleast 50 Reboots.
Refer RDKEMW-6934, RDKEMW-6935, RDKEMW-6785
Risks: High
Priority: P1