### PR TITLE
RDKEMW-7050 : fix coverity issues (#479)

### DIFF
--- a/PersistentStore/sqlite/Store2.h
+++ b/PersistentStore/sqlite/Store2.h
@@ -79,14 +79,11 @@ namespace Plugin {
             {
             }
             Store2(const string& path, const uint64_t maxSize, const uint64_t maxValue, const uint64_t limit)
-                : IStore2()
-                , IStoreCache()
-                , IStoreInspector()
-                , IStoreLimit()
-                , _path(path)
+                : _path(path)
                 , _maxSize(maxSize)
                 , _maxValue(maxValue)
                 , _limit(limit)
+                , _data(nullptr)
                 , _corrupt(false)
             {
                 TempDirectoryCheck();


### PR DESCRIPTION
Reason for change: initialize sqlite handle with nullptr to mute coverity report.
Test Procedure: None
Risks: None