### PR TITLE
RDKEMW-6861 : Add Telemetry support for LCM

### DIFF
--- a/LifecycleManager/ApplicationContext.cpp
+++ b/LifecycleManager/ApplicationContext.cpp
@@ -184,16 +184,22 @@ namespace WPEFramework
             return mKillParams;
 	}
 
-#ifdef ENABLE_AIMANAGERS_TELEMETRY_METRICS
         time_t ApplicationContext::getRequestTime()
         {
+#ifdef ENABLE_AIMANAGERS_TELEMETRY_METRICS
             return mRequestTime;
+#else
+            return 0;
+#endif
         }
 
         RequestType ApplicationContext::getRequestType()
         {
+#ifdef ENABLE_AIMANAGERS_TELEMETRY_METRICS
             return mRequestType;
-        }
+#else
+            return REQUEST_TYPE_NONE;
 #endif
+        }
     } /* namespace Plugin */
 } /* namespace WPEFramework */

--- a/LifecycleManager/ApplicationContext.h
+++ b/LifecycleManager/ApplicationContext.h
@@ -85,10 +85,8 @@ namespace WPEFramework
                 uint32_t getStateChangeId();
                 ApplicationLaunchParams& getApplicationLaunchParams();
                 ApplicationKillParams& getApplicationKillParams();
-#ifdef ENABLE_AIMANAGERS_TELEMETRY_METRICS
                 time_t getRequestTime();
                 RequestType getRequestType();
-#endif
 
                 sem_t mReachedLoadingStateSemaphore;
                 sem_t mAppRunningSemaphore;


### PR DESCRIPTION
Reason for change: Fixing compilation error when telemetry flag is not enabled.
Test Procedure: verified
Risks: Low
Priority: P1
Signed-off-by: Sourav Dutta bp-sdutta290@cable.comcast.com