### PR TITLE
RDKEMW-5331:log redirection specification before launching container

### DIFF
--- a/RuntimeManager/DobbySpecGenerator.cpp
+++ b/RuntimeManager/DobbySpecGenerator.cpp
@@ -152,13 +152,14 @@ bool DobbySpecGenerator::generate(const ApplicationConfiguration& config, const 
     cpuObj["cores"] = getCpuCores();
     spec["cpu"] = std::move(cpuObj);
 
-#if (AI_BUILD_TYPE == AI_DEBUG)
+//#if (AI_BUILD_TYPE == AI_DEBUG)
     Json::Value consoleObj;
     consoleObj["limit"] = mAIConfiguration->getContainerConsoleLogCap();
     //TODO: SUPPORT Read console path from runtime config: RDKEMW-4432
-    consoleObj["path"] = "/tmp/container.log";
+    //consoleObj["path"] = "/tmp/container.log";
+    consoleObj["path"] = "/opt/logs/apps/" + config.mAppId + ".log";
     spec["console"] = std::move(consoleObj);
-#endif // (AI_BUILD_TYPE == AI_DEBUG)
+//#endif // (AI_BUILD_TYPE == AI_DEBUG)
 
     Json::Value etcObj;
     Json::Value hostsArray(Json::arrayValue);


### PR DESCRIPTION
Updated the DobbySpecGenerator.cpp to redirect the log.