### PR TITLE
RDKEMW-8472: Appmanager L1 - update the test to fix intermittent failure  

### DIFF
--- a/Tests/L1Tests/tests/test_AppManager.cpp
+++ b/Tests/L1Tests/tests/test_AppManager.cpp
@@ -186,6 +186,9 @@ protected:
                     return Core::ERROR_NONE;
                 }));
 
+        ON_CALL(*p_wrapsImplMock, stat(::testing::_, ::testing::_))
+        .WillByDefault(::testing::Return(-1));
+        
         EXPECT_EQ(string(""), plugin->Initialize(mServiceMock));
         mAppManagerImpl = Plugin::AppManagerImplementation::getInstance();
         TEST_LOG("createResources - All done!");


### PR DESCRIPTION
Reason For change: Fix for L1 intermittent failure 
Test Procedure: verified
Risks: Medium
Priority: P1
Signed-off-by: Madhumathi R [bp-mbhand796@cable.comcast.com](mailto:bp-mbhand796@cable.comcast.com)