### PR TITLE
RDKEMW-10601: Change _automationId back to int

### DIFF
--- a/helpers/WsManager.h
+++ b/helpers/WsManager.h
@@ -21,7 +21,6 @@
 
 #include <mutex>
 #include <memory>
-#include <atomic>
 #include <plugins/plugins.h>
 #include "UtilsLogging.h"
 #include "WebSocketLink.h"
@@ -583,5 +582,5 @@ private:
     AuthHandler _authHandler;
     DisconnectHandler _disconnectHandler;
     WebSocketChannel *mChannel = nullptr;
-    std::atomic<uint32_t> _automationId{0};
+    uint32_t _automationId = 0;
 };


### PR DESCRIPTION
Reason For Change: Add Support for Bolt
Test procedure : Use the Firebolt APIs and establish connection with the Device similar to existing Firebolt Gateway
Priority: P1
Version: Minor