### PR TITLE
Revert "RDKEMW-13124: Wi‑Fi networks in the picker are not ordered by signalstrength"

### DIFF
--- a/FbSettings/delegate/NetworkDelegate.h
+++ b/FbSettings/delegate/NetworkDelegate.h
@@ -51,11 +51,6 @@ public:
     {
         if (mNetworkManager != nullptr)
         {
-            if (mNotificationHandler.GetRegistered())
-            {
-                mNetworkManager->Unregister(&mNotificationHandler);
-                mNotificationHandler.SetRegistered(false);
-            }
             mNetworkManager->Release();
             mNetworkManager = nullptr;
         }
@@ -215,6 +210,21 @@ private:
         NetworkNotificationHandler(NetworkDelegate &parent) : mParent(parent), registered(false) {}
         ~NetworkNotificationHandler() {}
 
+        void onInterfaceStateChange(const Exchange::INetworkManager::InterfaceState state, const string interface)
+        {
+            LOGDBG("onInterfaceStateChange: interface=%s, state=%d", interface.c_str(), state);
+        }
+
+        void onActiveInterfaceChange(const string prevActiveInterface, const string currentActiveInterface)
+        {
+            LOGDBG("onActiveInterfaceChange: prev=%s, current=%s", prevActiveInterface.c_str(), currentActiveInterface.c_str());
+        }
+
+        void onIPAddressChange(const string interface, const string ipversion, const string ipaddress, const Exchange::INetworkManager::IPStatus status)
+        {
+            LOGDBG("onIPAddressChange: interface=%s, ip=%s, status=%d", interface.c_str(), ipaddress.c_str(), status);
+        }
+
         void onInternetStatusChange(const Exchange::INetworkManager::InternetStatus prevState, const Exchange::INetworkManager::InternetStatus currState, const string interface)
         {
             LOGINFO("onInternetStatusChange: prevState=%d, currState=%d, interface=%s", prevState, currState, interface.c_str());
@@ -235,6 +245,21 @@ private:
             jsonStream << "{\"network\":{\"state\":\"" << statusToString(currState) 
                       << "\",\"prevState\":\"" << statusToString(prevState) << "\"}}";
             mParent.Dispatch("device.onNetworkChanged", jsonStream.str());
+        }
+
+        void onAvailableSSIDs(const string jsonOfScanResults)
+        {
+            LOGDBG("onAvailableSSIDs received");
+        }
+
+        void onWiFiStateChange(const Exchange::INetworkManager::WiFiState state)
+        {
+            LOGDBG("onWiFiStateChange: state=%d", state);
+        }
+
+        void onWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
+        {
+            LOGDBG("onWiFiSignalQualityChange: ssid=%s", ssid.c_str());
         }
 
         // Registration management methods


### PR DESCRIPTION
Reverts rdkcentral/entservices-infra#806