### PR TITLE
RDKEMW-18517: Fix Back-port mWsManager.Close() fix from RDKEMW-17793

### DIFF
--- a/AppGateway/AppGatewayResponderImplementation.cpp
+++ b/AppGateway/AppGatewayResponderImplementation.cpp
@@ -240,8 +240,9 @@ namespace WPEFramework
                     LOGERR("Resolver Failure");
                 }
             } else {
-                LOGERR("No App ID found for connection %d. Terminate connection", connectionId);
-                mWsManager.Close(connectionId);
+                // No App ID means the disconnect handler already ran and removed it from
+                // the registry. The connection is already gone; no explicit close needed.
+                LOGWARN("No App ID found for connection %d, connection already disconnected", connectionId);
             }
         }
 


### PR DESCRIPTION
RDKEMW-17793: Removed calling mWsManager.Close() on already-disconnected socket. 
RDKEMW-17793: mWsManager.Close(connectionId) called on already-disconnected socket causes crash in AppGateway
